### PR TITLE
Specify translation load paths for Rails 6

### DIFF
--- a/lib/bullet_train/conversations/engine.rb
+++ b/lib/bullet_train/conversations/engine.rb
@@ -1,6 +1,10 @@
 module BulletTrain
   module Conversations
     class Engine < ::Rails::Engine
+      config.before_initialize do
+        config.i18n.load_path += Dir["#{config.root}/config/locales/**/*.yml"]
+      end
+
       initializer "bullet_train.super_scaffolding.conversations.templates.register_template_path" do |app|
         # Register the base path of this package with the Super Scaffolding engine.
         BulletTrain::SuperScaffolding.template_paths << File.expand_path('../../../..', __FILE__)


### PR DESCRIPTION
This worked in Rails 7, but Rails 6 needs the config added explicitly