### PR TITLE
Better default for participant_parent_controller

### DIFF
--- a/lib/bullet_train/conversations.rb
+++ b/lib/bullet_train/conversations.rb
@@ -41,7 +41,7 @@ module BulletTrain
     def self.participant_parent_controller
       return class_variable_get("@@participant_parent_controller") if class_variable_get("@@participant_parent_controller").present?
       return "#{participant_namespace}::ApplicationController" if participant_namespace.present?
-      "ActionController::Base"
+      "Account::ApplicationController"
     end
 
     def self.participant_namespace_as_symbol


### PR DESCRIPTION
We can (probably) safely assume that this gem is being used in a BulletTrain app, and that the default controller should be `Account::ApplicationController` instead of `ActionController::Base`.

Fixes: https://github.com/bullet-train-pro/bullet_train-conversations/issues/21