### PR TITLE
Allow conversations to work without a `parent_association`

### DIFF
--- a/app/controllers/concerns/conversations/base_controller.rb
+++ b/app/controllers/concerns/conversations/base_controller.rb
@@ -18,7 +18,7 @@ module Conversations::BaseController
           subject = conversation_params[:subject_class].constantize.find(conversation_params[:subject_id])
 
           @conversation = subject.create_conversation_on_team
-          @parent = @conversation.send(BulletTrain::Conversations.parent_association)
+          @parent = BulletTrain::Conversations.parent_association.present? ? @conversation.send(BulletTrain::Conversations.parent_association) : nil
 
           @style = conversation_params[:style] || :conversation
           @conversation.update!(conversation_params.slice(:messages_attributes))

--- a/app/models/concerns/conversations/base.rb
+++ b/app/models/concerns/conversations/base.rb
@@ -2,7 +2,9 @@ module Conversations::Base
   extend ActiveSupport::Concern
 
   included do
-    belongs_to BulletTrain::Conversations.parent_association, class_name: BulletTrain::Conversations.parent_class
+    if BulletTrain::Conversations.parent_association.present?
+      belongs_to BulletTrain::Conversations.parent_association, class_name: BulletTrain::Conversations.parent_class
+    end
 
     if BulletTrain::Conversations.parent_class_specified?
       has_one :team, through: BulletTrain::Conversations.parent_association

--- a/app/models/concerns/conversations/messages/base.rb
+++ b/app/models/concerns/conversations/messages/base.rb
@@ -29,7 +29,9 @@ module Conversations::Messages::Base
 
     after_save :create_subscriptions_to_conversation, :mark_subscription_as_read
 
-    has_one BulletTrain::Conversations.parent_association, through: :conversation
+    if BulletTrain::Conversations.parent_association.present?
+      has_one BulletTrain::Conversations.parent_association, through: :conversation
+    end
 
     if BulletTrain::Conversations.parent_class_specified?
       # TODO I don't know whether this is the right thing to do here, but the goal here is to provide support for
@@ -55,7 +57,7 @@ module Conversations::Messages::Base
   end
 
   def parent
-    send(BulletTrain::Conversations.parent_association)
+    BulletTrain::Conversations.parent_association.present? ? send(BulletTrain::Conversations.parent_association) : nil
   end
 
   def mentioned_memberships

--- a/app/views/account/conversations/messages/_form.html.erb
+++ b/app/views/account/conversations/messages/_form.html.erb
@@ -1,7 +1,11 @@
 <%= turbo_frame_tag "message_form" do %>
   <% style ||= :conversation %>
   <% conversation_namespace = get_conversation_namespace %>
-  <%= form_with(model: conversation.persisted? ? [conversation_namespace, conversation, message] : [conversation_namespace, conversation.send(BulletTrain::Conversations.parent_association), conversation], class: 'new-message-form') do |form| %>
+  <% new_conversation_model = BulletTrain::Conversations.parent_association.present? ?
+    [conversation_namespace, conversation.send(BulletTrain::Conversations.parent_association), conversation] :
+    [conversation_namespace, conversation]
+  %>
+  <%= form_with(model: conversation.persisted? ? [conversation_namespace, conversation, message] : new_conversation_model , class: 'new-message-form') do |form| %>
 
     <%= form.hidden_field :style, value: style %>
     <%= render 'shared/forms/errors', form: form %>

--- a/lib/bullet_train/conversations.rb
+++ b/lib/bullet_train/conversations.rb
@@ -15,11 +15,11 @@ module BulletTrain
     mattr_accessor :participant_avatar_partial
 
     def self.parent_association
-      parent_class.underscore.to_sym
+      parent_class.present? ? parent_class.underscore.to_sym : nil
     end
 
     def self.parent_resource
-      parent_class.underscore.pluralize.to_sym
+      parent_class.present? ? parent_class.underscore.pluralize.to_sym : nil
     end
 
     def self.parent_class_specified?

--- a/lib/bullet_train/conversations.rb
+++ b/lib/bullet_train/conversations.rb
@@ -23,7 +23,7 @@ module BulletTrain
     end
 
     def self.parent_class_specified?
-      parent_class != "Team"
+      parent_class.present? && parent_class != "Team"
     end
 
     def self.participant_parent_association


### PR DESCRIPTION
This makes it so that conversations can be attached to models that don't belong directly to a `Team`.

To take advantage of it you'd do something like this:

```ruby
# config/initializers/bullet-train-conversations.rb

require "bullet_train/conversations"

BulletTrain::Conversations.parent_class = nil
```