### PR TITLE
Allow multiple conversations on one page

### DIFF
--- a/app/views/account/conversations/messages/_blog_comments.html.erb
+++ b/app/views/account/conversations/messages/_blog_comments.html.erb
@@ -2,7 +2,7 @@
 <% messages ||= conversation.messages.without_replies.newest %>
 <% heading ||= nil %>
 <% heading ||= "Start a conversation about this below!" if messages.empty? %>
-<% @message ||= conversation.messages.new unless hide_message_form %>
+<% new_message ||= @message || conversation.messages.new unless hide_message_form %>
 <% conversation.mark_read_for_membership(current_membership) %>
 
 <%= render 'account/shared/box' do |p| %>
@@ -12,11 +12,11 @@
       <div class="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
         <% unless hide_message_form %>
           <div class="chat-controls">
-            <%= render 'account/conversations/messages/form', conversation: conversation, message: @message, style: :blog %>
+            <%= render 'account/conversations/messages/form', conversation: conversation, message: new_message, style: :blog %>
           </div>
         <% end %>
       </div>
-      <%= cable_ready_updates_for @message.broadcast_key do  %>
+      <%= cable_ready_updates_for new_message.broadcast_key do  %>
         <div id="messages_<%= conversation.id %>" class="flex flex-col p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch relative">
           <%= turbo_frame_tag "messages" do %>
             <div>

--- a/app/views/account/conversations/messages/_field.html.erb
+++ b/app/views/account/conversations/messages/_field.html.erb
@@ -2,7 +2,7 @@
 <% mentions = conversations_message_mentions %>
 <%= form.hidden_field :parent_message_id, value: nil, data: { "reply-target": "parentMessage" } %>
 <div class="chat-input relative <%= 'pb-6' if mentions.none? %>">
-  <%= render 'shared/fields/trix_editor', form: form, method: :body, options: {placeholder: 'Type your message here ...', style: 'min-height: inherit;', autofocus: true, data: {"reply-target": "input", mentions: mentions}, class: "pt-5 pb-5 pl-5 pr-20 rounded-lg z-0 focus:shadow focus:outline-none", id: "conversations_message_#{message.id}_#{message.parent_message_id}"}, other_options: {hide_label: true, help: mentions.any? ? t('.mentions_help'): nil} do |p| %>
+  <%= render 'shared/fields/trix_editor', form: form, method: :body, options: {placeholder: 'Type your message here ...', style: 'min-height: inherit;', autofocus: true, data: {"reply-target": "input", mentions: mentions}, class: "pt-5 pb-5 pl-5 pr-20 rounded-lg z-0 focus:shadow focus:outline-none", id: "conversations_message_#{message.id}_#{message.parent_message_id}_#{message.broadcast_key}"}, other_options: {hide_label: true, help: mentions.any? ? t('.mentions_help'): nil} do |p| %>
     <% p.content_for :submit_button do %>
       <button type="submit" class="h-10 w-10 absolute inline-flex items-center justify-center rounded-full transition duration-500 ease-in-out text-white bg-blue-500 hover:bg-blue-400 focus:outline-none bottom-2 right-2">
         <i class="ti ti-arrow-up"></i>

--- a/app/views/account/conversations/messages/_form.html.erb
+++ b/app/views/account/conversations/messages/_form.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "message_form" do %>
+<%= turbo_frame_tag "message_form_#{message.broadcast_key}" do %>
   <% style ||= :conversation %>
   <% conversation_namespace = get_conversation_namespace %>
   <% new_conversation_model = BulletTrain::Conversations.parent_association.present? ?

--- a/app/views/account/conversations/messages/_index.html.erb
+++ b/app/views/account/conversations/messages/_index.html.erb
@@ -3,7 +3,7 @@
 <% messages ||= conversation.messages.oldest %>
 <% heading ||= nil %>
 <% heading ||= "Start a conversation about this below!" if messages.empty? %>
-<% @message ||= conversation.messages.new unless hide_message_form %>
+<% new_message ||= @message || conversation.messages.new unless hide_message_form %>
 <% conversation.mark_read_for_membership(current_membership) if current_membership %>
 <% if in_participant_namespace? %>
   <% conversation.mark_read_for_participant(send(BulletTrain::Conversations.current_participant_helper_method)) %>
@@ -39,7 +39,7 @@
       <% if hide_message_form %>
         <%= content_for :messages %>
       <% else %>
-        <%= cable_ready_updates_for @message.broadcast_key do %>
+        <%= cable_ready_updates_for new_message.broadcast_key do %>
           <%= content_for :messages %>
         <% end %>
       <% end %>
@@ -47,7 +47,7 @@
       <% unless hide_message_form %>
         <div class="border-t-2 border-gray-200 mb-2 pt-4 pb-6 px-8 sm:mb-0">
           <div class="chat-controls">
-            <%= render 'account/conversations/messages/form', conversation: conversation, message: @message %>
+            <%= render 'account/conversations/messages/form', conversation: conversation, message: new_message %>
           </div>
         </div>
       <% end %>

--- a/app/views/account/conversations/messages/create.turbo_stream.erb
+++ b/app/views/account/conversations/messages/create.turbo_stream.erb
@@ -1,11 +1,11 @@
 <% unless @message.reply? %>
   <% if @style.to_sym == :blog %>
     <% # TODO We need to make this respect `shared/conversations/comment` the same way `render` does in `bullet_train-themes`. %>
-    <%= turbo_stream.prepend "messages", partial: "themes/light/conversations/comment", locals: {message: @message, next_message: nil, new_message: true} %>
+    <%= turbo_stream.prepend "messages_#{@message.broadcast_key}", partial: "themes/light/conversations/comment", locals: {message: @message, next_message: nil, new_message: true} %>
   <% else %>
     <% # TODO We need to make this respect `shared/conversations/comment` the same way `render` does in `bullet_train-themes`. %>
-    <%= turbo_stream.append "messages", partial: "themes/light/conversations/message", locals: {message: @message, next_message: nil, new_message: true} %>
+    <%= turbo_stream.append "messages_#{@message.broadcast_key}", partial: "themes/light/conversations/message", locals: {message: @message, next_message: nil, new_message: true} %>
   <% end %>
 <% end %>
 
-<%= turbo_stream.replace "message_form", partial: "account/conversations/messages/form", locals: {conversation: @conversation, message: @conversation.messages.new, style: @style&.to_sym} %>
+<%= turbo_stream.replace "message_form_#{@message.broadcast_key}", partial: "account/conversations/messages/form", locals: {conversation: @conversation, message: @conversation.messages.new, style: @style&.to_sym} %>


### PR DESCRIPTION
Previously we had non-unique ids assigned to forms, form elements, turbo frames and cable ready update/broadcast calls. This makes it so that we use the `broadcast_id` of the current message in all of those identifiers. That makes it so that different conversations on the same page will play nicely together.

Fixes #28 